### PR TITLE
fix(ui): restore jQuery wrapper behavior in app events

### DIFF
--- a/ui/static/js/app.js
+++ b/ui/static/js/app.js
@@ -29,8 +29,8 @@ import { scrollToElement, setBusy } from "./ui-utils.js";
 
 let elements;
 
-function $() {
-  return window.jQuery;
+function $(...args) {
+  return window.jQuery(...args);
 }
 
 function refreshWorkflowPanel() {


### PR DESCRIPTION
## Overview
This follow-up PR fixes a regression introduced during the UI modularization refactor.

## Problem
In `ui/static/js/app.js`, the local `$` helper returned `window.jQuery` itself instead of invoking it. As a result, expressions such as `$(this)` returned the jQuery function object rather than a jQuery-wrapped element, which broke delegated event handlers with runtime errors like:

```
Uncaught TypeError: $button.closest is not a function
```

## Fix
- change the helper from returning `window.jQuery` to calling `window.jQuery(...args)`
- restore expected jQuery object behavior for edit/delete/toggle workflow interactions

## Verification
- ran `node --check ui/static/js/app.js`
- confirmed the fix is isolated to the wrapper helper and only changes `ui/static/js/app.js`