### PR TITLE
Split CI into backend and frontend jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  ci:
-    name: CI
+  backend:
+    name: Backend
     runs-on: ubuntu-latest
 
     steps:
@@ -30,6 +30,14 @@ jobs:
 
       - name: Run Python compile checks
         run: python -m compileall scripts ui
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary\n- split the GitHub Actions workflow into dedicated backend and frontend jobs\n- keep Python compile checks in the backend job\n- keep frontend tests and build in the frontend job\n\n## Validation\n- python3 -m compileall scripts ui\n- npm test\n- npm run build\n