### PR TITLE
Docs: add local ComfyUI server routes reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This project is a ComfyUI skill integration layer for OpenClaw. It turns the wor
 
 It converts natural language requests into structured skill arguments, maps them to ComfyUI workflow inputs, submits jobs to ComfyUI, waits for completion, then pulls generated images back to local disk.
 
+For the upstream ComfyUI local server routes that back this skill, see [docs/comfyui-native-routes.md](./docs/comfyui-native-routes.md).
+
 ## What This Skill Can Do
 
 - Turn your existing ComfyUI workflows into skills that OpenClaw can call directly
@@ -18,6 +20,21 @@ It converts natural language requests into structured skill arguments, maps them
 - Reuse the parameters you already exposed so OpenClaw can understand what each workflow expects
 - Upload a workflow once, manage it in the UI, and reuse it without rebuilding the setup
 - Submit jobs to ComfyUI, wait for completion, and pull generated images back to local storage
+
+## ComfyUI Native API Scope
+
+This repository should be understood as two layers:
+
+- Native ComfyUI server routes on the target generation server, such as `/prompt`, `/history/{prompt_id}`, `/view`, `/ws`, and `/queue`
+- This project's own manager API under `/api/*`, used by the local UI to manage saved servers, workflows, and transfer bundles
+
+The current skill implementation is centered on the native execution flow:
+
+1. `POST /prompt`
+2. `GET /history/{prompt_id}`
+3. `GET /view`
+
+That route-level reference is documented in [docs/comfyui-native-routes.md](./docs/comfyui-native-routes.md).
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -27,6 +27,20 @@ This command will:
 - start it in the background if it is not running
 - try to open the browser to the local dashboard automatically
 
+### Native ComfyUI API Surface
+
+This skill is primarily a workflow execution client for a local or remote ComfyUI server.
+
+The core native ComfyUI routes relevant to this skill are:
+
+- `POST /prompt` to submit a workflow run
+- `GET /history/{prompt_id}` to poll for completion
+- `GET /view` to download generated images
+
+Other native ComfyUI routes such as `/ws`, `/queue`, `/interrupt`, `/upload/image`, `/object_info`, and `/system_stats` exist upstream but are not required for the basic execution path implemented here.
+
+For the route-level reference and the distinction between native ComfyUI routes and this repository's own manager API, see [`docs/comfyui-native-routes.md`](./docs/comfyui-native-routes.md).
+
 ### Step 0: AI-Native Workflow Auto-Configuration (Optional)
 
 If the user provides you with a new ComfyUI workflow JSON (API format) and asks you to "configure it" or "add it":
@@ -85,6 +99,7 @@ python ./scripts/comfyui_client.py --workflow <server_id>/<workflow_id> --args '
 **Blocking and Result Retrieval**:
 - This script will automatically submit the task to the matched server and **poll to wait** for ComfyUI to finish rendering, then download the image locally.
 - If executed successfully, the standard output of the script will finally provide a JSON containing an `images` list, where the absolute paths are the generated image files.
+- Under the hood, this flow uses the native ComfyUI route sequence `POST /prompt` -> `GET /history/{prompt_id}` -> `GET /view`.
 
 ### Step 4: Send the Image to the User
 

--- a/docs/comfyui-native-routes.md
+++ b/docs/comfyui-native-routes.md
@@ -1,0 +1,244 @@
+---
+title: ComfyUI Native Local Routes
+---
+
+# ComfyUI Native Local Routes
+
+This page documents the native HTTP and WebSocket routes exposed by a local ComfyUI server, with emphasis on the subset that matters to this skill.
+
+It is intentionally separate from this repository's own manager API in `ui/app.py`. If you are looking for routes such as `/api/servers` or `/api/transfer/*`, those belong to this project, not to upstream ComfyUI.
+
+Official ComfyUI references:
+
+- [Server Overview](https://docs.comfy.org/development/comfyui-server/comms_overview)
+- [Routes](https://docs.comfy.org/development/comfyui-server/comms_routes)
+
+The official links in this document intentionally use the English documentation only.
+
+This document is intentionally limited to the local ComfyUI server documentation under `development/comfyui-server/*`.
+
+It does not use `api-reference/cloud/*`, `api-reference/registry/*`, or other official API-reference sections, even if some route names overlap.
+
+## Scope
+
+This skill is an execution-oriented ComfyUI client. It does not attempt to expose every upstream ComfyUI capability through the agent contract.
+
+Today, the critical native routes for this repository are:
+
+- `POST /prompt`
+- `GET /history/{prompt_id}`
+- `GET /view`
+
+These are the routes used to submit a workflow, wait for completion, and download generated images.
+
+## Core Calling Patterns
+
+Assume a local ComfyUI server at `http://127.0.0.1:8188`.
+
+### Submit A Workflow
+
+Route:
+
+- `POST /prompt`
+
+How to call:
+
+- Content type: `application/json`
+- Body shape:
+
+```json
+{
+  "prompt": {
+    "3": {
+      "inputs": {
+        "seed": 1,
+        "steps": 20,
+        "cfg": 8,
+        "sampler_name": "euler",
+        "scheduler": "normal",
+        "denoise": 1,
+        "model": ["4", 0],
+        "positive": ["6", 0],
+        "negative": ["7", 0],
+        "latent_image": ["5", 0]
+      },
+      "class_type": "KSampler"
+    }
+  },
+  "client_id": "optional-client-id"
+}
+```
+
+Example:
+
+```bash
+curl -X POST http://127.0.0.1:8188/prompt \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "prompt": {
+      "3": {
+        "inputs": {
+          "seed": 1,
+          "steps": 20
+        },
+        "class_type": "KSampler"
+      }
+    },
+    "client_id": "openclaw-skill"
+  }'
+```
+
+Expected response:
+
+- Success: returns `prompt_id` and queue `number`
+- Failure: returns `error` and `node_errors`
+
+Official docs:
+
+- [Routes](https://docs.comfy.org/development/comfyui-server/comms_routes)
+
+### Poll For Completion
+
+Route:
+
+- `GET /history/{prompt_id}`
+
+How to call:
+
+- Replace `{prompt_id}` with the value returned by `POST /prompt`
+- No request body
+
+Example:
+
+```bash
+curl http://127.0.0.1:8188/history/<prompt_id>
+```
+
+What to look for:
+
+- A history object keyed by `prompt_id`
+- `outputs` containing generated image entries
+- Each image entry usually includes `filename`, `subfolder`, and `type`
+
+Official docs:
+
+- [Routes](https://docs.comfy.org/development/comfyui-server/comms_routes)
+
+### Download An Output Image
+
+Route:
+
+- `GET /view`
+
+How to call:
+
+- Query parameters typically include:
+- `filename`
+- `subfolder`
+- `type`
+
+Example:
+
+```bash
+curl "http://127.0.0.1:8188/view?filename=ComfyUI_00001_.png&subfolder=&type=output" \
+  --output result.png
+```
+
+Official docs:
+
+- [Routes](https://docs.comfy.org/development/comfyui-server/comms_routes)
+- Note: the official page says `/view` has many options and points readers to the upstream `server.py` handler for details.
+
+### Receive Live Status
+
+Route:
+
+- `WS /ws`
+
+How to call:
+
+- Open a WebSocket connection to `/ws`
+- Receive JSON messages such as `status`, `execution_start`, `executing`, `progress`, and `executed`
+
+Official docs:
+
+- [Routes](https://docs.comfy.org/development/comfyui-server/comms_routes)
+
+## Route Groups
+
+### Execution
+
+| Route | Method | Purpose | Call shape | Skill status |
+| --- | --- | --- | --- | --- |
+| `/prompt` | `POST` | Submit a workflow to the execution queue. Returns `prompt_id` on success or validation errors on failure. | JSON body with `prompt`, optional `client_id` | Used now |
+| `/prompt` | `GET` | Inspect current prompt queue status and execution information. | No body | Not used |
+| `/history` | `GET` | Read execution history for finished or recorded runs. | No body | Not used directly |
+| `/history/{prompt_id}` | `GET` | Read the history entry for one run. This is how the client polls for completion. | Path param `prompt_id` | Used now |
+| `/history` | `POST` | Clear history or delete a history item. | JSON body, operation-specific | Not used |
+| `/queue` | `GET` | Inspect the current execution queue. | No body | Not used |
+| `/queue` | `POST` | Manage queue operations such as clearing pending or running work. | JSON body, operation-specific | Candidate |
+| `/interrupt` | `POST` | Stop the currently running workflow. | Usually empty body | Candidate |
+| `/ws` | `WS` | Real-time execution progress, status changes, and node events. | WebSocket connection | Candidate |
+| `/free` | `POST` | Free memory by unloading specified models. | JSON body, operation-specific | Candidate |
+
+### Assets And Files
+
+| Route | Method | Purpose | Call shape | Skill status |
+| --- | --- | --- | --- | --- |
+| `/view` | `GET` | Download or inspect an output image by filename, subfolder, and type. | Query params such as `filename`, `subfolder`, `type` | Used now |
+| `/upload/image` | `POST` | Upload an image into ComfyUI-managed storage. Useful for image-to-image or reference-image workflows. | Multipart form upload | Candidate |
+| `/upload/mask` | `POST` | Upload a mask for inpainting-style workflows. | Multipart form upload | Candidate |
+| `/view_metadata` | `GET` | Retrieve metadata for a model or asset. | Query params | Not used |
+| `/userdata` and `/v2/userdata` | `GET` | List user data files. | Query params, route-specific | Not used |
+| `/userdata/{file}` | `GET/POST/DELETE` | Read, write, or delete specific user data files. | Path param plus body for upload/update | Not used |
+
+### Discovery And Introspection
+
+| Route | Method | Purpose | Call shape | Skill status |
+| --- | --- | --- | --- | --- |
+| `/object_info` | `GET` | Return details for all node types. Useful for building smarter workflow/schema tooling. | No body | Candidate |
+| `/object_info/{node_class}` | `GET` | Return details for one node type. | Path param `node_class` | Candidate |
+| `/models` | `GET` | Return available model folders or model types. | No body | Candidate |
+| `/models/{folder}` | `GET` | Return models within a specific folder. | Path param `folder` | Candidate |
+| `/embeddings` | `GET` | Return available embeddings. | No body | Candidate |
+| `/features` | `GET` | Return server capabilities and feature flags. | No body | Candidate |
+| `/system_stats` | `GET` | Return system information such as devices and VRAM. | No body | Candidate |
+| `/workflow_templates` | `GET` | Return template workflows exposed by custom node modules. | No body | Not used |
+| `/extensions` | `GET` | Return registered web extensions. | No body | Not used |
+
+## What This Repository Uses Today
+
+The current CLI client in `scripts/comfyui_client.py` follows a minimal three-step native ComfyUI flow:
+
+1. `POST /prompt` to queue the workflow.
+2. `GET /history/{prompt_id}` until the run appears in history.
+3. `GET /view` for each generated image returned by the history entry.
+
+That design keeps the skill narrow and reliable. It only depends on the routes required to run a prepared workflow and fetch the resulting files.
+
+## What Could Be Added Next
+
+If this skill expands beyond basic workflow execution, the most valuable native ComfyUI routes to integrate next are:
+
+- `/ws` for real-time progress updates instead of polling-only completion checks.
+- `/interrupt` so the agent or UI can cancel long-running jobs.
+- `/queue` so the manager can inspect backlog and surface queue state.
+- `/upload/image` and `/upload/mask` for image-to-image, control, and inpainting workflows.
+- `/object_info` for smarter schema generation and validation against upstream node definitions.
+- `/models` and `/system_stats` for server capability discovery before dispatching a workflow.
+
+## Native ComfyUI Routes vs Project Manager API
+
+Use this distinction consistently:
+
+- ComfyUI native routes: upstream routes on the target ComfyUI server, usually something like `http://127.0.0.1:8188`.
+- Project manager API: this repository's FastAPI routes under `/api/*`, served by `ui/app.py`, used to manage saved servers, workflows, and transfer bundles.
+
+Examples of project manager routes:
+
+- `/api/config`
+- `/api/servers`
+- `/api/workflows`
+- `/api/transfer/export/preview`
+
+These project routes orchestrate local configuration and workflow metadata. They do not replace the upstream ComfyUI server routes used for actual workflow execution.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,4 +20,5 @@ This project turns ComfyUI workflows into callable skills, so skill-capable agen
 - [GitHub Repository](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw)
 - [English README](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw/blob/main/README.md)
 - [Chinese README](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw/blob/main/README.zh.md)
+- [ComfyUI Native Local Routes](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw/blob/main/docs/comfyui-native-routes.md)
 - [Project Discovery Checklist](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw/blob/main/docs/PROJECT_DISCOVERY_CHECKLIST.md)


### PR DESCRIPTION
## Summary
- add a dedicated English reference for local ComfyUI server routes
- document the native local routes currently used by this skill and related route groups
- link the new reference from the README, SKILL.md, and docs index

## Scope
- local ComfyUI server documentation only
- no cloud, registry, or admin API coverage in the new routes reference

## Testing
- not run (docs-only changes)