### PR TITLE
docs: update roadmap with completed milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,9 +388,14 @@ Default import behavior:
 
 ## Roadmap
 
-- [ ] Workflow version history and rollback
+- [x] Split frontend source into a standalone repository
+- [x] Server health monitoring with live UI indicators
+- [x] Configuration import/export for cross-machine migration
+- [x] First-class support for OpenClaw, Claude Code, and Codex
+- [x] Multilingual UI (English, Simplified Chinese, Traditional Chinese)
 - [x] Upgrade preview before applying a new workflow version
 - [x] Parameter migration support when upgrading a workflow
+- [ ] Workflow version history and rollback
 - [ ] Better schema validation before queueing
 - [ ] Richer error reporting from ComfyUI node errors
 - [ ] Optional batch generation / multi-seed helpers

--- a/README.zh.md
+++ b/README.zh.md
@@ -385,9 +385,14 @@ python scripts/transfer_manager.py import --input ./openclaw-skill-export.json
 
 ## 路线图
 
-- [ ] 支持工作流版本历史和回滚
+- [x] 前端源码分离到独立仓库
+- [x] 服务器健康状态检测与 UI 指示器
+- [x] 配置导入导出，支持跨机器迁移
+- [x] 多 Agent 支持（OpenClaw / Claude Code / Codex）
+- [x] 多语言界面（英文 / 简体中文 / 繁体中文）
 - [x] 上传新版本前先预览参数变化
 - [x] 工作流升级时支持参数迁移
+- [ ] 支持工作流版本历史和回滚
 - [ ] 增强提交前参数校验
 - [ ] 更清晰展示 ComfyUI 返回的节点错误
 - [ ] 支持批量多 seed 生成


### PR DESCRIPTION
## Summary
- Roadmap 新增 5 项已完成的里程碑：前端分离、健康检测、配置迁移、多 Agent 支持、多语言界面
- 已完成项排在前面，待办项排在后面
- 同步更新英文和中文 README

## Test plan
- [ ] 确认 README.md 和 README.zh.md 的 Roadmap 内容一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)