### PR TITLE
feat: add frontend update check API

### DIFF
--- a/scripts/shared/frontend_update.py
+++ b/scripts/shared/frontend_update.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+FRONTEND_REPO = "HuangYuChuh/ComfyUI_Skills_OpenClaw-frontend"
+GITHUB_API_URL = f"https://api.github.com/repos/{FRONTEND_REPO}/releases/tags/latest"
+CACHE_TTL = 600  # 10 minutes
+
+_cache: dict[str, object] = {}
+
+
+def check_frontend_update(static_dir: Path) -> dict:
+    """Compare local frontend version against the latest rolling release."""
+    local = _read_local_version(static_dir)
+    if not local:
+        return {"has_update": False, "error": "no_local_version"}
+
+    remote = _fetch_remote_version()
+    if not remote:
+        return {"has_update": False, "error": "fetch_failed"}
+
+    local_commit = local.get("commit", "")
+    remote_commit = remote.get("commit", "")
+
+    if not local_commit or not remote_commit:
+        return {"has_update": False, "error": "missing_commit"}
+
+    has_update = local_commit != remote_commit
+    return {
+        "has_update": has_update,
+        "local_commit": local_commit[:8],
+        "remote_commit": remote_commit[:8],
+        "remote_date": remote.get("date", ""),
+    }
+
+
+def _read_local_version(static_dir: Path) -> dict | None:
+    version_file = static_dir / "version.json"
+    if not version_file.is_file():
+        return None
+    try:
+        return json.loads(version_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _fetch_remote_version() -> dict | None:
+    now = time.monotonic()
+    cached = _cache.get("remote_version")
+    cached_at = _cache.get("cached_at", 0.0)
+    if cached and isinstance(cached_at, float) and now - cached_at < CACHE_TTL:
+        return cached  # type: ignore[return-value]
+
+    try:
+        req = urllib.request.Request(
+            GITHUB_API_URL,
+            headers={"Accept": "application/vnd.github+json"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            release = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+        logger.debug("Failed to fetch latest release: %s", exc)
+        return None
+
+    # Try to find version.json in release assets
+    assets = release.get("assets", [])
+    version_asset = next(
+        (a for a in assets if a.get("name") == "version.json"),
+        None,
+    )
+
+    if version_asset:
+        try:
+            download_url = version_asset["browser_download_url"]
+            req = urllib.request.Request(download_url)
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                result = json.loads(resp.read().decode("utf-8"))
+                _cache["remote_version"] = result
+                _cache["cached_at"] = now
+                return result
+        except (urllib.error.URLError, OSError, json.JSONDecodeError, KeyError) as exc:
+            logger.debug("Failed to download version.json asset: %s", exc)
+
+    # Fallback: parse commit from release body
+    body = release.get("body", "")
+    for line in body.splitlines():
+        if "Commit:" in line:
+            commit = line.split("`")[-2] if "`" in line else line.split(":")[-1].strip()
+            result = {"commit": commit, "date": release.get("published_at", "")}
+            _cache["remote_version"] = result
+            _cache["cached_at"] = now
+            return result
+
+    return None

--- a/scripts/update_frontend.sh
+++ b/scripts/update_frontend.sh
@@ -2,16 +2,17 @@
 set -euo pipefail
 
 REPO="HuangYuChuh/ComfyUI_Skills_OpenClaw-frontend"
+TAG="${1:-latest}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 STATIC_DIR="$ROOT_DIR/ui/static"
 
-echo "Fetching latest release from $REPO ..."
+echo "Fetching release '$TAG' from $REPO ..."
 
-DOWNLOAD_URL=$(gh release view --repo "$REPO" --json assets \
+DOWNLOAD_URL=$(gh release view "$TAG" --repo "$REPO" --json assets \
   --jq '.assets[] | select(.name == "frontend-dist.tar.gz") | .url')
 
 if [[ -z "$DOWNLOAD_URL" ]]; then
-  echo "Error: frontend-dist.tar.gz not found in the latest release." >&2
+  echo "Error: frontend-dist.tar.gz not found in release '$TAG'." >&2
   exit 1
 fi
 
@@ -19,11 +20,15 @@ TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 echo "Downloading frontend-dist.tar.gz ..."
-gh release download --repo "$REPO" --pattern "frontend-dist.tar.gz" --dir "$TMP_DIR"
+gh release download "$TAG" --repo "$REPO" --pattern "frontend-dist.tar.gz" --dir "$TMP_DIR"
 
 echo "Extracting to $STATIC_DIR ..."
 rm -rf "$STATIC_DIR"
 mkdir -p "$STATIC_DIR"
 tar -xzf "$TMP_DIR/frontend-dist.tar.gz" -C "$STATIC_DIR"
+
+if [[ -f "$STATIC_DIR/version.json" ]]; then
+  echo "Version: $(cat "$STATIC_DIR/version.json")"
+fi
 
 echo "Done. Frontend assets updated in ui/static/"

--- a/ui/app.py
+++ b/ui/app.py
@@ -46,6 +46,7 @@ except ImportError:
     from services import UIStorageService
     from settings import DEFAULT_HOST, DEFAULT_PORT, STATIC_DIR, ensure_runtime_dirs
 
+from shared.frontend_update import check_frontend_update
 from shared.health import check_server_health
 from shared.transfer_bundle import (
     BundleValidationError,
@@ -208,6 +209,12 @@ def create_app() -> FastAPI:
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
         return {"status": "success", "workflow_order": workflow_order}
+
+    # ── Frontend Update ─────────────────────────────────────────
+
+    @app.get("/api/frontend/check-update")
+    async def frontend_check_update() -> dict:
+        return await asyncio.to_thread(check_frontend_update, STATIC_DIR)
 
     # ── Transfer Bundle ───────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- 新增 `/api/frontend/check-update` API，对比本地 `ui/static/version.json` 和 GitHub `latest` Release 的版本
- 10 分钟缓存避免频繁请求 GitHub API
- `update_frontend.sh` 改为默认从 `latest` Release 下载，支持 `./scripts/update_frontend.sh v0.1.0` 指定版本

## Test plan
- [ ] 启动 UI 后访问 `/api/frontend/check-update` 确认返回正确
- [ ] 运行 `./scripts/update_frontend.sh` 确认能从 latest Release 下载

🤖 Generated with [Claude Code](https://claude.com/claude-code)