### PR TITLE
docs: add new roadmap items

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,11 @@ Default import behavior:
 - [x] Multilingual UI (English, Simplified Chinese, Traditional Chinese)
 - [x] Upgrade preview before applying a new workflow version
 - [x] Parameter migration support when upgrading a workflow
+- [ ] Authentication support for remote ComfyUI servers
+- [ ] Execution history with parameter and result tracking
+- [ ] Webhook callbacks on task completion
+- [ ] Scheduled workflow execution (cron-style)
+- [ ] Guided workflow rewrite recipes for agents
 - [ ] Workflow version history and rollback
 - [ ] Better schema validation before queueing
 - [ ] Richer error reporting from ComfyUI node errors

--- a/README.zh.md
+++ b/README.zh.md
@@ -392,6 +392,11 @@ python scripts/transfer_manager.py import --input ./openclaw-skill-export.json
 - [x] 多语言界面（英文 / 简体中文 / 繁体中文）
 - [x] 上传新版本前先预览参数变化
 - [x] 工作流升级时支持参数迁移
+- [ ] 远程 ComfyUI 服务器鉴权支持
+- [ ] 执行历史记录（参数 + 结果追溯）
+- [ ] 任务完成后 Webhook 回调通知
+- [ ] 定时执行工作流（cron 风格）
+- [ ] 引导式工作流改写模板（Rewrite Recipe）
 - [ ] 支持工作流版本历史和回滚
 - [ ] 增强提交前参数校验
 - [ ] 更清晰展示 ComfyUI 返回的节点错误


### PR DESCRIPTION
## Summary
- Roadmap 新增 5 项待实现功能：远程服务器鉴权、执行历史、Webhook 回调、定时任务、Rewrite Recipe

## Test plan
- [ ] 确认中英文 README 内容一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)