### PR TITLE
fix(ci): use PAT for sync-frontend so CI triggers on created PRs

### DIFF
--- a/.github/workflows/sync-frontend.yml
+++ b/.github/workflows/sync-frontend.yml
@@ -4,8 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   sync:
@@ -15,6 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
+          token: ${{ secrets.MAIN_REPO_TOKEN }}
 
       - name: Download latest frontend dist
         run: |
@@ -23,7 +23,7 @@ jobs:
             --pattern "frontend-dist.tar.gz" \
             --output frontend-dist.tar.gz
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.MAIN_REPO_TOKEN }}
 
       - name: Extract dist to ui/static
         run: |
@@ -44,7 +44,7 @@ jobs:
       - name: Commit, open PR and enable auto-merge
         if: steps.diff.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.MAIN_REPO_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

- Switch `sync-frontend` workflow from `github.token` to `MAIN_REPO_TOKEN` (PAT)
- PRs created with `GITHUB_TOKEN` cannot trigger CI workflows (GitHub security restriction)
- With a PAT, the created PR triggers the Backend CI check, enabling `--auto` merge to work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)