### PR TITLE
docs: remove batch generation from roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Default import behavior:
 - [ ] Workflow version history and rollback
 - [x] Better schema validation before queueing
 - [x] Richer error reporting from ComfyUI node errors
-- [ ] Optional batch generation / multi-seed helpers
+
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -402,7 +402,7 @@ python scripts/transfer_manager.py import --input ./openclaw-skill-export.json
 - [ ] 支持工作流版本历史和回滚
 - [x] 增强提交前参数校验
 - [x] 更清晰展示 ComfyUI 返回的节点错误
-- [ ] 支持批量多 seed 生成
+
 
 ---
 


### PR DESCRIPTION
## Summary
- 从 Roadmap 中移除 "Optional batch generation / multi-seed helpers"
- Agent 本身已能通过多次调用实现批量生成，无需专门功能