### PR TITLE
fix: surface schema load errors and normalize update_server inputs

### DIFF
--- a/scripts/registry.py
+++ b/scripts/registry.py
@@ -1,12 +1,15 @@
 import os
 import json
 import argparse
-
 import sys
+from logging import getLogger
+
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from shared.config import get_server_schema_path, list_server_workflow_dirs
 from shared.runtime_config import get_runtime_config
+
+logger = getLogger(__name__)
 
 
 def get_workflows(is_agent=False):
@@ -71,8 +74,8 @@ def get_workflows(is_agent=False):
                         }
 
                 all_workflows.append(workflow_info)
-            except Exception:
-                pass
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning("Skipping workflow '%s/%s': %s", server_id, workflow_id, e)
 
     if is_agent:
         # Clean internal fields

--- a/ui/services.py
+++ b/ui/services.py
@@ -123,9 +123,16 @@ class UIStorageService:
         config = self.get_config()
         for s in config.get("servers", []):
             if s.get("id") == server_id:
-                for key in ("name", "url", "auth", "enabled", "output_dir"):
-                    if key in updates:
-                        s[key] = updates[key]
+                if "name" in updates:
+                    s["name"] = str(updates["name"] or "").strip() or server_id
+                if "url" in updates:
+                    s["url"] = str(updates["url"] or "").strip()
+                if "auth" in updates:
+                    s["auth"] = str(updates["auth"] or "").strip()
+                if "enabled" in updates:
+                    s["enabled"] = bool(updates["enabled"])
+                if "output_dir" in updates:
+                    s["output_dir"] = str(updates["output_dir"] or "./outputs").strip() or "./outputs"
                 self.save_config(config)
                 return self._serialize_server_for_ui(s)
         raise FileNotFoundError(f"Server '{server_id}' not found")


### PR DESCRIPTION
## Summary
- `registry.py`: 将 `except Exception: pass` 替换为具体异常捕获 + warning 日志，schema.json 损坏时不再静默消失，而是输出可定位的警告
- `services.py`: `update_server` 对每个字段做与 `add_server` 一致的输入规范化（去空白、类型强制、默认值回退），消除 add/update 行为不一致导致的潜在 config 污染

## Test plan
- [ ] 故意写坏某个 workflow 的 schema.json，确认 `registry list` 输出 warning 而非静默跳过
- [ ] 通过 UI 更新 server，传入带空白或空值的字段，确认 config 中写入的是规范化后的数据

🤖 Generated with [Claude Code](https://claude.com/claude-code)