### PR TITLE
docs: update changelog and readme for release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.0] - 2026-04-08
+
+### Added
+
+- **CLI-first architecture** — All workflow operations now go through the standalone [ComfyUI Skill CLI](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI). Legacy Python scripts have been removed (#89 ~ #98)
+- **Multilingual README** — Added Simplified Chinese, Traditional Chinese, and Japanese translations (#105)
+- **Japanese UI** — Frontend now supports Japanese locale (#115)
+
+### Fixed
+
+- **Duplicate node parameter collision** — Workflows with duplicate nodes no longer lose parameters due to schema name collision (#87, #88)
+- **Web UI upload dependency** — Fixed broken upload functionality in the web UI (#111)
+
+### Improved
+
+- Redesigned README badges and banner (#107, #112, #116, #117)
+- SKILL.md rewritten with full CLI command reference (#91, #92, #101)
+
 ## [0.3.1] - 2026-03-30
 
 ### Added

--- a/CHANGELOG.zh.md
+++ b/CHANGELOG.zh.md
@@ -4,6 +4,24 @@
 
 格式遵循 [Keep a Changelog](https://keepachangelog.com/)，版本号遵循[语义化版本](https://semver.org/)。
 
+## [0.4.0] - 2026-04-08
+
+### Added
+
+- **CLI 优先架构** — 所有工作流操作统一通过独立的 [ComfyUI Skill CLI](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI) 执行，旧版 Python 脚本已移除 (#89 ~ #98)
+- **多语言 README** — 新增简体中文、繁体中文、日语版本 (#105)
+- **日语 UI** — 前端新增日语界面支持 (#115)
+
+### Fixed
+
+- **重复节点参数丢失** — 工作流中存在重复节点时，参数因 schema 名称冲突被覆盖 (#87, #88)
+- **Web UI 上传依赖修复** — 修复 Web UI 中上传功能异常 (#111)
+
+### Improved
+
+- 重新设计 README 徽章和横幅图 (#107, #112, #116, #117)
+- SKILL.md 全面改写为 CLI 命令参考 (#91, #92, #101)
+
 ## [0.3.1] - 2026-03-30
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -469,9 +469,9 @@ comfyui-skill deps check <workflow_id>
 
 最近の主な更新:
 
+- **v0.4.0**: [CLI ファーストアーキテクチャ](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI)へ移行 — すべてのワークフロー操作（`run`、`submit`、`status`、`import`、`deps`）をスタンドアロン CLI に統一、レガシー Python スクリプトを削除
 - **v0.3.1**: Kling、Sora、Nano Banana などのクラウド API ノード向けに ComfyUI API Key サポートを追加
 - **v0.3.0**: 依存関係チェックとインストール、非同期 `submit` / `status`、画像アップロード、インポートプレビュー、実行履歴を追加
-- **v0.2.0**: フロントエンドのソースコードを別リポジトリへ移し、自動同期フローを追加
 
 完全な変更履歴は [CHANGELOG.md](./CHANGELOG.md) を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -468,9 +468,9 @@ Then install supported dependencies if needed.
 
 Recent highlights:
 
+- **v0.4.0**: Migrated to [CLI-first architecture](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI) — all workflow operations (`run`, `submit`, `status`, `import`, `deps`) now go through a standalone CLI tool; legacy Python scripts have been removed.
 - **v0.3.1**: Added ComfyUI API Key support for cloud API nodes such as Kling, Sora, and Nano Banana.
 - **v0.3.0**: Added dependency check and install, non-blocking `submit` and `status`, image upload, import preview, and execution history.
-- **v0.2.0**: Moved frontend source code into a separate repository and added automated frontend sync support.
 
 See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -468,9 +468,9 @@ comfyui-skill deps check <workflow_id>
 
 最近的重要更新：
 
+- **v0.4.0**：遷移至 [CLI 優先架構](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI) — 所有工作流操作（`run`、`submit`、`status`、`import`、`deps`）統一透過獨立 CLI 執行，舊版 Python 腳本已移除。
 - **v0.3.1**：新增 ComfyUI API Key 支援，可用於 Kling、Sora、Nano Banana 等雲 API 節點。
 - **v0.3.0**：新增依賴檢查與安裝、非阻塞 `submit` / `status`、圖片上傳、匯入預覽與執行歷史。
-- **v0.2.0**：將前端原始碼拆分到獨立倉庫，並加入前端自動同步能力。
 
 完整版本記錄見 [CHANGELOG.zh.md](./CHANGELOG.zh.md)。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -468,9 +468,9 @@ comfyui-skill deps check <workflow_id>
 
 最近的重要更新：
 
+- **v0.4.0**：迁移至 [CLI 优先架构](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI) — 所有工作流操作（`run`、`submit`、`status`、`import`、`deps`）统一通过独立 CLI 执行，旧版 Python 脚本已移除。
 - **v0.3.1**：新增 ComfyUI API Key 支持，可用于 Kling、Sora、Nano Banana 等云 API 节点。
 - **v0.3.0**：新增依赖检查与安装、非阻塞 `submit` / `status`、图片上传、导入预览和执行历史。
-- **v0.2.0**：将前端源码拆分到独立仓库，并加入前端自动同步能力。
 
 完整版本记录见 [CHANGELOG.zh.md](./CHANGELOG.zh.md)。
 


### PR DESCRIPTION
Release documentation update for version 0.4.0 featuring the CLI-first architecture. Updates include CHANGELOG and multi-language README files.