### PR TITLE
[codex] Declare ComfyUI CLI dependency

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -7,6 +7,10 @@ description: |
   (1) The user requests to "generate an image", "draw a picture", or "execute a ComfyUI workflow".
   (2) The user has specific stylistic, character, or scene requirements for image generation.
   (3) The user asks you to import, register, sync, or configure saved ComfyUI workflows for later reuse.
+metadata:
+  requires:
+    bins: ["comfyui-skill"]
+  cliHelp: "comfyui-skill --help"
 ---
 
 # ComfyUI Agent SKILL


### PR DESCRIPTION
## Summary

- Declare the `comfyui-skill` binary dependency in the skill metadata.
- Add `cliHelp` so agent environments can discover the CLI help command, matching the pattern used by the Lark skills.

## Impact

This prepares the skill for environments that inspect skill metadata for required CLI binaries. The CLI itself remains responsible for version and update behavior.

## Validation

- `git diff --check`
