### PR TITLE
docs: add Korean/Spanish READMEs, normalize zh-CN, add CLI nav

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,424 @@
+<div align="center">
+  <img src="./asset/banner.png" alt="ComfyUI Skills Banner">
+
+  <h1>ComfyUI Skills for OpenClaw</h1>
+
+  <p><strong>Skills de flujo de trabajo ComfyUI amigables con agentes para OpenClaw, Codex, Claude Code y otros agentes.</strong></p>
+
+  <p>
+    Este proyecto convierte los flujos de trabajo de ComfyUI en skills invocables, con una CLI amigable para agentes como interfaz principal
+    y una Web UI visual para facilitar la configuración y las pruebas.
+  </p>
+
+  <p>
+    <a href="https://huangyuchuh.github.io/ComfyUI_Skills_OpenClaw/"><img src="https://img.shields.io/badge/docs-GitHub_Pages-4F46E5?style=flat&logo=gitbook&logoColor=white" alt="Docs"></a>
+    <a href="https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw/blob/main/LICENSE"><img src="https://img.shields.io/github/license/HuangYuChuh/ComfyUI_Skills_OpenClaw?style=flat&color=10B981&logo=data%3Aimage/svg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxwYXRoIGQ9Im0xNiAxNiAzLTggMyA4Yy0uODcuNjUtMS45MiAxLTMgMXMtMi4xMy0uMzUtMy0xWiIvPjxwYXRoIGQ9Im0yIDE2IDMtOCAzIDhjLS44Ny42NS0xLjkyIDEtMyAxcy0yLjEzLS4zNS0zLTFaIi8%2BPHBhdGggZD0iTTcgMjFoMTAiLz48cGF0aCBkPSJNMTIgM3YxOCIvPjxwYXRoIGQ9Ik0zIDdoMmMyIDAgNS0xIDctMiAyIDEgNSAyIDcgMmgyIi8%2BPC9zdmc%2B" alt="License"></a>
+    <a href="https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw/stargazers"><img src="https://img.shields.io/github/stars/HuangYuChuh/ComfyUI_Skills_OpenClaw?style=flat&color=EAB308&logo=github" alt="GitHub stars"></a>
+    <a href="https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw/network/members"><img src="https://img.shields.io/github/forks/HuangYuChuh/ComfyUI_Skills_OpenClaw?style=flat&color=F97316&logo=github" alt="GitHub forks"></a>
+    <a href="https://www.python.org/"><img src="https://img.shields.io/static/v1?label=Python&message=3.10%2B&color=3B82F6&style=flat&logo=python&logoColor=white" alt="Python 3.10+"></a>
+  </p>
+
+  <p>
+    <a href="https://www.bilibili.com/video/BV1a6cUzVEE6/">🎬 Video de demostración</a> ·
+    <a href="https://huangyuchuh.github.io/ComfyUI_Skills_OpenClaw/">📘 Documentación</a> ·
+    <a href="#quick-start">🧭 Inicio rápido</a> ·
+    <a href="#cli">⌨️ CLI</a> ·
+    <a href="#web-ui">🖥️ Web UI</a> ·
+    <a href="#multi-server-management">🛰️ Multi-servidor</a>
+  </p>
+
+  <p>
+    <a href="./README.md">English</a> ·
+    <a href="./README.zh-CN.md">简体中文</a> ·
+    <a href="./README.zh-TW.md">繁體中文</a> ·
+    <a href="./README.ja.md">日本語</a> ·
+    <a href="./README.ko.md">한국어</a> ·
+    <strong>Español</strong>
+  </p>
+
+  <blockquote>Este documento fue traducido automáticamente. Las contribuciones para mejorar la traducción son bienvenidas.</blockquote>
+</div>
+
+---
+
+## Descripción general
+
+ComfyUI Skills for OpenClaw es un puente amigable para agentes que convierte flujos de trabajo de ComfyUI en skills invocables por agentes.
+
+En lugar de hacer que un agente manipule grafos crudos de ComfyUI, este proyecto proporciona a cada flujo de trabajo una interfaz limpia y controlada a través de una CLI y un mapeo de parámetros basado en esquemas. Funciona con OpenClaw, Codex, Claude Code y otros agentes que pueden ejecutar comandos de shell.
+
+Úsalo cuando quieras importar flujos de trabajo existentes de ComfyUI, exponer solo los parámetros importantes, ejecutarlos desde el chat o tareas de agentes, y gestionar todo a través de una capa de flujo de trabajo consistente.
+
+| Ideal para | Lo que obtienes |
+|------------|-----------------|
+| Usuarios de OpenClaw, Codex y Claude Code | Una capa de flujo de trabajo ComfyUI que los agentes pueden llamar de forma segura |
+| Propietarios de flujos de trabajo ComfyUI existentes | Una forma limpia de reutilizar flujos de trabajo exportados sin exponer el grafo completo |
+| Configuraciones multi-máquina | Un namespace unificado para servidores ComfyUI locales y remotos |
+| Usuarios que desean configuración y pruebas visuales | Una Web UI opcional para configurar, previsualizar y validar flujos de trabajo antes de que los agentes los usen |
+
+## Características
+
+| Capacidad | Por qué importa |
+|-----------|-----------------|
+| **CLI amigable para agentes** | Diseñada para agentes, no solo para humanos. Proporciona una interfaz más limpia y confiable que trabajar directamente con grafos crudos de ComfyUI o patrones de interacción de nivel inferior. |
+| **Mapeo de parámetros basado en esquemas** | Expone solo los campos que deseas que el agente controle, con alias, tipos y descripciones claras. |
+| **Importación de flujos de trabajo ComfyUI** | Importa archivos JSON de flujos de trabajo, detecta formatos automáticamente y genera la capa de mapeo necesaria para el uso del agente. |
+| **Enrutamiento multi-servidor** | Gestiona servidores ComfyUI locales y remotos bajo un namespace y enruta trabajos a la máquina correcta. |
+| **Gestión de dependencias** | Verifica nodos y modelos faltantes antes de la ejecución e instala dependencias soportadas a través de la CLI. |
+| **Web UI opcional** | Una capa visual para configuración y pruebas. No reemplaza la CLI; las acciones orientadas al agente siguen mapeándose al mismo flujo de trabajo CLI. |
+
+<a id="quick-start"></a>
+## Inicio rápido
+
+Pon en marcha ComfyUI Skills en unos minutos.
+
+Antes de comenzar, asegúrate de tener:
+
+- Python 3.10+
+- Un servidor ComfyUI en ejecución
+- Un flujo de trabajo exportado en formato API de ComfyUI si deseas probar la ejecución de inmediato
+
+### 1. Clonar el proyecto
+
+Elige el directorio que corresponda a tu entorno de agente.
+
+<details>
+<summary><strong>Para OpenClaw</strong></summary>
+
+```bash
+cd ~/.openclaw/workspace/skills
+git clone https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw.git comfyui-skill-openclaw
+cd comfyui-skill-openclaw
+```
+
+</details>
+
+<details>
+<summary><strong>Para Claude Code</strong></summary>
+
+```bash
+cd ~/.claude/skills
+git clone https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw.git comfyui-skill
+cd comfyui-skill
+```
+
+</details>
+
+<details>
+<summary><strong>Para Codex</strong></summary>
+
+```bash
+cd ~/.codex/skills
+git clone https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw.git comfyui-skill
+cd comfyui-skill
+```
+
+</details>
+
+### 2. Crear la configuración local
+
+```bash
+cp config.example.json config.json
+```
+
+### 3. Instalar la CLI
+
+```bash
+pipx install comfyui-skill-cli
+```
+
+O:
+
+```bash
+pip install comfyui-skill-cli
+```
+
+Si ya tienes la CLI instalada, actualízala con:
+
+```bash
+# Si la instalaste con pipx
+pipx upgrade comfyui-skill-cli
+
+# Si la instalaste con pip
+python3 -m pip install -U comfyui-skill-cli
+```
+
+### 4. Verificar la configuración
+
+```bash
+comfyui-skill server status
+comfyui-skill list
+```
+
+### 5. Importar y ejecutar tu primer flujo de trabajo
+
+```bash
+comfyui-skill workflow import /absolute/path/to/my-workflow.json
+comfyui-skill deps check local/my-workflow
+comfyui-skill run local/my-workflow --args '{"prompt": "a white cat"}'
+```
+
+Para importaciones manuales por CLI, se recomienda pasar la ruta absoluta del JSON del flujo de trabajo. Esto evita ambigüedades de ruta y mantiene el modelo de almacenamiento simple.
+
+Por ejemplo:
+
+```bash
+comfyui-skill workflow import /Users/yourname/Downloads/my-workflow.json
+```
+
+Después de la importación, la CLI almacena el flujo de trabajo normalizado y el esquema en `data/<server_id>/<workflow_id>/`, por ejemplo `data/local/my-workflow/workflow.json` y `data/local/my-workflow/schema.json`.
+
+Este es también el layout formal usado por la Web UI y por las importaciones de Agent/OpenClaw:
+
+```bash
+data/<server_id>/<workflow_id>/
+  workflow.json
+  schema.json
+  history/
+```
+
+En este punto, la CLI leerá tu `config.json` local, descubrirá los flujos de trabajo disponibles y los ejecutará a través de tu servidor ComfyUI.
+
+Si prefieres un flujo de configuración y pruebas visual, consulta la sección [Web UI](#web-ui) a continuación.
+
+## Opciones de configuración
+
+Elige la ruta que corresponda a cómo deseas usar el proyecto.
+
+### OpenClaw
+
+Usa esta ruta si deseas que OpenClaw descubra y ejecute flujos de trabajo ComfyUI como skills.
+
+- Clona el repositorio en `~/.openclaw/workspace/skills`
+- Instala `comfyui-skill-cli`
+- Configura `config.json`
+- Importa flujos de trabajo y expone parámetros seguros para el agente
+
+### Codex o Claude Code
+
+Usa esta ruta si deseas que agentes de codificación llamen flujos de trabajo ComfyUI mediante comandos de shell.
+
+- Clona el repositorio en el directorio de skills de tu agente
+- Instala la CLI
+- Verifica con `comfyui-skill list`
+- Ejecuta flujos de trabajo con `--args` estructurados
+
+### Web UI
+
+Usa esta ruta si deseas una interfaz visual para configuración, inspección y pruebas. Consulta la sección [Web UI](#web-ui) a continuación para instrucciones de lanzamiento y detalles.
+
+### Configuración manual
+
+Usa esta ruta si deseas control directo sobre `config.json`, `workflow.json` y `schema.json`.
+
+<details>
+<summary><strong>Expandir para configuración manual de archivos</strong></summary>
+
+#### 1) Editar `config.json`
+
+```jsonc
+{
+  "servers": [
+    {
+      "id": "local",
+      "name": "Local",
+      "url": "http://127.0.0.1:8188",
+      "enabled": true,
+      "output_dir": "./outputs"
+    }
+  ],
+  "default_server": "local"
+}
+```
+
+#### 2) Colocar archivos de flujo de trabajo
+
+```text
+data/local/my-workflow/
+  workflow.json  # Exportación en formato API de ComfyUI
+  schema.json    # Mapeo de parámetros
+```
+
+#### 3) Escribir `schema.json`
+
+```jsonc
+{
+  "description": "My workflow",
+  "enabled": true,
+  "parameters": {
+    "prompt": {
+      "node_id": 10,
+      "field": "prompt",
+      "required": true,
+      "type": "string",
+      "description": "Prompt text"
+    }
+  }
+}
+```
+
+</details>
+
+<a id="cli"></a>
+## Comandos comunes
+
+Además de los comandos mostrados en [Inicio rápido](#quick-start), estas son operaciones adicionales que podrías necesitar:
+
+### Inspeccionar un flujo de trabajo
+
+```bash
+comfyui-skill info local/txt2img
+```
+
+### Enviar un flujo de trabajo de forma asíncrona
+
+```bash
+comfyui-skill submit local/txt2img --args '{"prompt": "a white cat"}'
+comfyui-skill status <prompt_id>
+```
+
+### Gestionar servidores
+
+```bash
+comfyui-skill server list
+comfyui-skill server add --id remote --url http://10.0.0.1:8188
+```
+
+Para la referencia completa de la CLI, ejecuta `comfyui-skill --help` o consulta [ComfyUI Skill CLI](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI).
+
+## Requisitos de flujos de trabajo
+
+Para funcionar de manera confiable con este proyecto, cada flujo de trabajo debe cumplir estos requisitos.
+
+- El flujo de trabajo debe exportarse desde ComfyUI en formato API.
+- El flujo de trabajo debe incluir un nodo de salida como `Save Image`.
+- El flujo de trabajo necesita un mapeo `schema.json` para que el agente pueda trabajar con una interfaz de parámetros limpia.
+- El servidor ComfyUI de destino debe tener instalados los nodos personalizados y modelos requeridos.
+
+Si usas `comfyui-skill workflow import`, la CLI puede ayudar a generar el mapeo necesario y verificar dependencias antes de la ejecución.
+
+<a id="multi-server-management"></a>
+## Gestión multi-servidor
+
+Este proyecto está diseñado para funcionar con más de un servidor ComfyUI.
+
+Puedes mantener múltiples instancias locales o remotas de ComfyUI bajo una configuración y enrutar flujos de trabajo por namespace. Esto es útil cuando diferentes máquinas sirven para diferentes propósitos, como pruebas locales ligeras, trabajos con GPU grandes o entornos específicos de modelos.
+
+Ejemplos:
+
+```bash
+comfyui-skill server add --id local --url http://127.0.0.1:8188
+comfyui-skill server add --id remote-a100 --url http://10.0.0.20:8188
+comfyui-skill server list
+```
+
+Los flujos de trabajo se direccionan con el formato:
+
+```text
+<server_id>/<workflow_id>
+```
+
+Por ejemplo:
+
+```text
+local/txt2img
+remote-a100/sdxl-base
+```
+
+Tanto servidores como flujos de trabajo admiten interruptores de activación y desactivación, para que los agentes solo vean los flujos de trabajo actualmente disponibles.
+
+También puedes mover configuraciones entre máquinas con:
+
+```bash
+comfyui-skill config export --output ./backup.json
+comfyui-skill config import ./backup.json --dry-run
+comfyui-skill config import ./backup.json
+```
+
+<a id="web-ui"></a>
+## Web UI
+
+Una interfaz web local está disponible para configuración y pruebas visuales. Es opcional y existe para facilitar la configuración, inspección y validación. El skill en sí está diseñado para que los agentes lo usen a través de la CLI.
+
+### Lanzamiento
+
+```bash
+./ui/run_ui.sh                    # macOS/Linux
+# o: ui\run_ui.bat                # Windows
+```
+
+Los scripts de lanzamiento crean un `.venv` del proyecto cuando es necesario e instalan las dependencias de la UI en ese entorno virtual. No se requiere instalación global de dependencias de la Web UI.
+
+Visita `http://localhost:18189`.
+
+### Lo que puedes hacer en la Web UI
+
+- Subir flujos de trabajo exportados desde ComfyUI
+- Configurar mapeos de parámetros con un editor visual
+- Gestionar múltiples servidores y flujos de trabajo en un solo lugar
+- Buscar, reordenar e inspeccionar definiciones de flujos de trabajo
+- Probar y validar la configuración de flujos de trabajo antes de pasarlos a los agentes
+- Usar la interfaz en English, 简体中文 o 繁體中文
+
+Todo lo que la Web UI configura se mapea al mismo flujo de trabajo CLI subyacente. Es un compañero visual para la configuración y las pruebas, no un modelo de ejecución separado.
+
+El código fuente del frontend está en un [repositorio separado](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw-frontend).
+
+## Problemas comunes
+
+### HTTP 400 en `/prompt`
+
+El payload del flujo de trabajo o uno de los valores de parámetros inyectados es inválido.
+
+Verifica:
+
+- Si el flujo de trabajo fue exportado en formato API
+- Si el mapeo del esquema apunta al nodo y campo correctos
+- Si los tipos de argumentos proporcionados coinciden con el esquema
+
+### No se devuelven imágenes
+
+El flujo de trabajo puede estar faltando un nodo de salida válido como `Save Image`.
+
+### Fallo de conexión
+
+Verifica que:
+
+- El servidor ComfyUI está en ejecución
+- La URL del servidor en `config.json` es correcta
+- El servidor seleccionado está habilitado
+
+### Nodos o modelos faltantes
+
+Ejecuta:
+
+```bash
+comfyui-skill deps check <workflow_id>
+```
+
+Luego instala las dependencias soportadas si es necesario.
+
+## Registro de cambios
+
+Destacados recientes:
+
+- **v0.4.0**: Migración a [arquitectura CLI-first](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI) — todas las operaciones de flujo de trabajo (`run`, `submit`, `status`, `import`, `deps`) ahora pasan por una herramienta CLI independiente; los scripts legacy de Python han sido eliminados.
+- **v0.3.1**: Soporte de API Key de ComfyUI para nodos de API en la nube como Kling, Sora y Nano Banana.
+- **v0.3.0**: Verificación e instalación de dependencias, `submit` y `status` no bloqueantes, carga de imágenes, previsualización de importación e historial de ejecución.
+
+Consulta [CHANGELOG.md](./CHANGELOG.md) para el historial completo de versiones.
+
+## Contribuir
+
+¡Las contribuciones son bienvenidas! Por favor lee [CONTRIBUTING.md](./CONTRIBUTING.md) antes de enviar un PR.
+
+## Recursos
+
+- [English README](./README.md)
+- [简体中文 README](./README.zh-CN.md)
+- [繁體中文 README](./README.zh-TW.md)
+- [日本語 README](./README.ja.md)
+- [한국어 README](./README.ko.md)
+- [Español README](./README.es.md)
+- [ComfyUI Skill CLI](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI)
+- [Frontend Repository](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw-frontend)

--- a/README.ja.md
+++ b/README.ja.md
@@ -23,15 +23,18 @@
     <a href="https://www.bilibili.com/video/BV1a6cUzVEE6/">🎬 Demo Video</a> ·
     <a href="https://huangyuchuh.github.io/ComfyUI_Skills_OpenClaw/">📘 Docs</a> ·
     <a href="#quick-start">🧭 クイックスタート</a> ·
+    <a href="#cli">⌨️ CLI</a> ·
     <a href="#web-ui">🖥️ Web UI</a> ·
     <a href="#multi-server-management">🛰️ マルチサーバー</a>
   </p>
 
   <p>
     <a href="./README.md">English</a> ·
-    <a href="./README.zh.md">简体中文</a> ·
+    <a href="./README.zh-CN.md">简体中文</a> ·
     <a href="./README.zh-TW.md">繁體中文</a> ·
-    <strong>日本語</strong>
+    <strong>日本語</strong> ·
+    <a href="./README.ko.md">한국어</a> ·
+    <a href="./README.es.md">Español</a>
   </p>
 </div>
 
@@ -304,6 +307,7 @@ ComfyUI workflow.json
 
 この構造により、Agent は生の ComfyUI graph ノードを理解する代わりに、安定した呼び出し契約を扱うことができます。
 
+<a id="cli"></a>
 ## よく使うコマンド
 
 以下は最も一般的な操作に使うコマンドです。
@@ -482,8 +486,10 @@ comfyui-skill deps check <workflow_id>
 ## 関連リソース
 
 - [English README](./README.md)
-- [简体中文 README](./README.zh.md)
+- [简体中文 README](./README.zh-CN.md)
 - [繁體中文 README](./README.zh-TW.md)
 - [日本語 README](./README.ja.md)
+- [한국어 README](./README.ko.md)
+- [Español README](./README.es.md)
 - [ComfyUI Skill CLI](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI)
 - [Frontend Repository](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw-frontend)

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,424 @@
+<div align="center">
+  <img src="./asset/banner.png" alt="ComfyUI Skills Banner">
+
+  <h1>ComfyUI Skills for OpenClaw</h1>
+
+  <p><strong>OpenClaw, Codex, Claude Code 및 기타 에이전트를 위한 Agent 친화적 ComfyUI 워크플로우 스킬입니다.</strong></p>
+
+  <p>
+    이 프로젝트는 ComfyUI 워크플로우를 호출 가능한 스킬로 변환합니다. Agent 친화적인 CLI를 주 인터페이스로 제공하며,
+    설정과 테스트를 위한 시각적 Web UI도 함께 제공합니다.
+  </p>
+
+  <p>
+    <a href="https://huangyuchuh.github.io/ComfyUI_Skills_OpenClaw/"><img src="https://img.shields.io/badge/docs-GitHub_Pages-4F46E5?style=flat&logo=gitbook&logoColor=white" alt="Docs"></a>
+    <a href="https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw/blob/main/LICENSE"><img src="https://img.shields.io/github/license/HuangYuChuh/ComfyUI_Skills_OpenClaw?style=flat&color=10B981&logo=data%3Aimage/svg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxwYXRoIGQ9Im0xNiAxNiAzLTggMyA4Yy0uODcuNjUtMS45MiAxLTMgMXMtMi4xMy0uMzUtMy0xWiIvPjxwYXRoIGQ9Im0yIDE2IDMtOCAzIDhjLS44Ny42NS0xLjkyIDEtMyAxcy0yLjEzLS4zNS0zLTFaIi8%2BPHBhdGggZD0iTTcgMjFoMTAiLz48cGF0aCBkPSJNMTIgM3YxOCIvPjxwYXRoIGQ9Ik0zIDdoMmMyIDAgNS0xIDctMiAyIDEgNSAyIDcgMmgyIi8%2BPC9zdmc%2B" alt="License"></a>
+    <a href="https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw/stargazers"><img src="https://img.shields.io/github/stars/HuangYuChuh/ComfyUI_Skills_OpenClaw?style=flat&color=EAB308&logo=github" alt="GitHub stars"></a>
+    <a href="https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw/network/members"><img src="https://img.shields.io/github/forks/HuangYuChuh/ComfyUI_Skills_OpenClaw?style=flat&color=F97316&logo=github" alt="GitHub forks"></a>
+    <a href="https://www.python.org/"><img src="https://img.shields.io/static/v1?label=Python&message=3.10%2B&color=3B82F6&style=flat&logo=python&logoColor=white" alt="Python 3.10+"></a>
+  </p>
+
+  <p>
+    <a href="https://www.bilibili.com/video/BV1a6cUzVEE6/">🎬 데모 영상</a> ·
+    <a href="https://huangyuchuh.github.io/ComfyUI_Skills_OpenClaw/">📘 문서</a> ·
+    <a href="#quick-start">🧭 빠른 시작</a> ·
+    <a href="#cli">⌨️ CLI</a> ·
+    <a href="#web-ui">🖥️ Web UI</a> ·
+    <a href="#multi-server-management">🛰️ 멀티 서버</a>
+  </p>
+
+  <p>
+    <a href="./README.md">English</a> ·
+    <a href="./README.zh-CN.md">简体中文</a> ·
+    <a href="./README.zh-TW.md">繁體中文</a> ·
+    <a href="./README.ja.md">日本語</a> ·
+    <strong>한국어</strong> ·
+    <a href="./README.es.md">Español</a>
+  </p>
+
+  <blockquote>이 문서는 기계 번역으로 작성되었습니다. 번역 개선 기여를 환영합니다.</blockquote>
+</div>
+
+---
+
+## 개요
+
+ComfyUI Skills for OpenClaw는 ComfyUI 워크플로우를 에이전트가 호출할 수 있는 스킬로 변환하는 Agent 친화적 브릿지입니다.
+
+에이전트가 원시 ComfyUI 그래프를 직접 조작하도록 하는 대신, CLI와 스키마 기반 파라미터 매핑을 통해 각 워크플로우에 깔끔하고 제어 가능한 인터페이스를 제공합니다. 셸 명령을 실행할 수 있는 OpenClaw, Codex, Claude Code 및 기타 에이전트와 함께 작동합니다.
+
+기존 ComfyUI 워크플로우를 가져오고, 필요한 파라미터만 노출하고, 채팅이나 에이전트 작업에서 실행하고, 하나의 일관된 워크플로우 레이어로 모든 것을 관리하고 싶을 때 사용하세요.
+
+| 대상 사용자 | 제공하는 것 |
+|-------------|-------------|
+| OpenClaw, Codex, Claude Code 사용자 | 에이전트가 안전하게 호출할 수 있는 ComfyUI 워크플로우 레이어 |
+| 기존 ComfyUI 워크플로우 소유자 | 전체 그래프를 노출하지 않고 내보낸 워크플로우를 재사용하는 방법 |
+| 다중 머신 환경 | 로컬 및 원격 ComfyUI 서버를 위한 단일 네임스페이스 |
+| 시각적 설정 및 테스트를 원하는 사용자 | 에이전트에 전달하기 전에 워크플로우를 설정, 미리보기, 검증할 수 있는 선택적 Web UI |
+
+## 기능
+
+| 기능 | 가치 |
+|------|------|
+| **Agent 친화적 CLI** | 에이전트를 위해 설계되었습니다. 원시 ComfyUI 그래프나 저수준 ComfyUI 상호작용 패턴보다 더 깔끔하고 신뢰할 수 있는 인터페이스를 제공합니다. |
+| **스키마 기반 파라미터 매핑** | 에이전트가 제어할 필드만 노출하고, 명확한 별칭, 타입, 설명을 제공합니다. |
+| **ComfyUI 워크플로우 가져오기** | 워크플로우 JSON 파일을 가져오고, 형식을 자동 감지하며, 에이전트 사용에 필요한 매핑 레이어를 생성합니다. |
+| **멀티 서버 라우팅** | 로컬 및 원격 ComfyUI 서버를 하나의 네임스페이스로 관리하고 적절한 머신으로 작업을 라우팅합니다. |
+| **의존성 관리** | 실행 전에 누락된 노드와 모델을 확인하고 CLI를 통해 지원되는 의존성을 설치합니다. |
+| **선택적 Web UI** | 설정 및 테스트를 위한 시각적 레이어입니다. CLI를 대체하지 않으며, 에이전트 대상 액션은 동일한 CLI 워크플로우에 매핑됩니다. |
+
+<a id="quick-start"></a>
+## 빠른 시작
+
+몇 분 만에 ComfyUI Skills를 실행하세요.
+
+시작하기 전에 다음을 준비하세요:
+
+- Python 3.10+
+- 실행 중인 ComfyUI 서버
+- 바로 실행을 테스트하려면 ComfyUI API 형식으로 내보낸 워크플로우
+
+### 1. 프로젝트 클론
+
+에이전트 환경에 맞는 디렉토리를 선택하세요.
+
+<details>
+<summary><strong>OpenClaw 용</strong></summary>
+
+```bash
+cd ~/.openclaw/workspace/skills
+git clone https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw.git comfyui-skill-openclaw
+cd comfyui-skill-openclaw
+```
+
+</details>
+
+<details>
+<summary><strong>Claude Code 용</strong></summary>
+
+```bash
+cd ~/.claude/skills
+git clone https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw.git comfyui-skill
+cd comfyui-skill
+```
+
+</details>
+
+<details>
+<summary><strong>Codex 용</strong></summary>
+
+```bash
+cd ~/.codex/skills
+git clone https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw.git comfyui-skill
+cd comfyui-skill
+```
+
+</details>
+
+### 2. 로컬 설정 생성
+
+```bash
+cp config.example.json config.json
+```
+
+### 3. CLI 설치
+
+```bash
+pipx install comfyui-skill-cli
+```
+
+또는:
+
+```bash
+pip install comfyui-skill-cli
+```
+
+이미 CLI가 설치되어 있다면 다음으로 업그레이드하세요:
+
+```bash
+# pipx로 설치한 경우
+pipx upgrade comfyui-skill-cli
+
+# pip로 설치한 경우
+python3 -m pip install -U comfyui-skill-cli
+```
+
+### 4. 설정 확인
+
+```bash
+comfyui-skill server status
+comfyui-skill list
+```
+
+### 5. 첫 번째 워크플로우 가져오기 및 실행
+
+```bash
+comfyui-skill workflow import /absolute/path/to/my-workflow.json
+comfyui-skill deps check local/my-workflow
+comfyui-skill run local/my-workflow --args '{"prompt": "a white cat"}'
+```
+
+수동 CLI 가져오기 시 워크플로우 JSON의 절대 경로를 전달하는 것을 권장합니다. 경로 모호성을 피하고 스토리지 모델을 단순하게 유지할 수 있습니다.
+
+예시:
+
+```bash
+comfyui-skill workflow import /Users/yourname/Downloads/my-workflow.json
+```
+
+가져오기 후 CLI는 정규화된 워크플로우와 스키마를 `data/<server_id>/<workflow_id>/` 아래에 저장합니다. 예: `data/local/my-workflow/workflow.json` 및 `data/local/my-workflow/schema.json`.
+
+이것은 Web UI와 Agent/OpenClaw 가져오기에서도 사용하는 공식 레이아웃입니다:
+
+```bash
+data/<server_id>/<workflow_id>/
+  workflow.json
+  schema.json
+  history/
+```
+
+이 시점에서 CLI는 로컬 `config.json`을 읽고, 사용 가능한 워크플로우를 검색하고, ComfyUI 서버를 통해 실행합니다.
+
+시각적 설정 및 테스트 흐름을 선호한다면 아래의 [Web UI](#web-ui) 섹션을 참조하세요.
+
+## 설정 옵션
+
+사용 방식에 맞는 경로를 선택하세요.
+
+### OpenClaw
+
+OpenClaw가 ComfyUI 워크플로우를 스킬로 검색하고 실행하도록 하려면 이 경로를 사용하세요.
+
+- 리포지토리를 `~/.openclaw/workspace/skills`에 클론
+- `comfyui-skill-cli` 설치
+- `config.json` 설정
+- 워크플로우를 가져오고 에이전트가 안전하게 사용할 수 있는 파라미터 노출
+
+### Codex 또는 Claude Code
+
+코딩 에이전트가 셸 명령을 통해 ComfyUI 워크플로우를 호출하도록 하려면 이 경로를 사용하세요.
+
+- 리포지토리를 에이전트 스킬 디렉토리에 클론
+- CLI 설치
+- `comfyui-skill list`로 확인
+- 구조화된 `--args`로 워크플로우 실행
+
+### Web UI
+
+시각적 인터페이스로 설정, 검사, 테스트를 하고 싶다면 이 경로를 사용하세요. 자세한 내용은 아래의 [Web UI](#web-ui) 섹션을 참조하세요.
+
+### 수동 설정
+
+`config.json`, `workflow.json`, `schema.json`을 직접 제어하고 싶다면 이 경로를 사용하세요.
+
+<details>
+<summary><strong>수동 설정 파일 예시 펼치기</strong></summary>
+
+#### 1) `config.json` 편집
+
+```jsonc
+{
+  "servers": [
+    {
+      "id": "local",
+      "name": "Local",
+      "url": "http://127.0.0.1:8188",
+      "enabled": true,
+      "output_dir": "./outputs"
+    }
+  ],
+  "default_server": "local"
+}
+```
+
+#### 2) 워크플로우 파일 배치
+
+```text
+data/local/my-workflow/
+  workflow.json  # ComfyUI API 형식 내보내기
+  schema.json    # 파라미터 매핑
+```
+
+#### 3) `schema.json` 작성
+
+```jsonc
+{
+  "description": "My workflow",
+  "enabled": true,
+  "parameters": {
+    "prompt": {
+      "node_id": 10,
+      "field": "prompt",
+      "required": true,
+      "type": "string",
+      "description": "Prompt text"
+    }
+  }
+}
+```
+
+</details>
+
+<a id="cli"></a>
+## 자주 사용하는 명령어
+
+[빠른 시작](#quick-start)에서 보여준 명령어 외에 필요할 수 있는 추가 작업입니다:
+
+### 워크플로우 검사
+
+```bash
+comfyui-skill info local/txt2img
+```
+
+### 워크플로우 비동기 제출
+
+```bash
+comfyui-skill submit local/txt2img --args '{"prompt": "a white cat"}'
+comfyui-skill status <prompt_id>
+```
+
+### 서버 관리
+
+```bash
+comfyui-skill server list
+comfyui-skill server add --id remote --url http://10.0.0.1:8188
+```
+
+전체 CLI 레퍼런스는 `comfyui-skill --help`를 실행하거나 [ComfyUI Skill CLI](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI)를 참조하세요.
+
+## 워크플로우 요구사항
+
+이 프로젝트에서 안정적으로 작동하려면 각 워크플로우가 다음 요구사항을 충족해야 합니다.
+
+- 워크플로우는 ComfyUI에서 API 형식으로 내보내야 합니다.
+- 워크플로우에는 `Save Image`와 같은 출력 노드가 포함되어야 합니다.
+- 에이전트가 깔끔한 파라미터 인터페이스로 작업할 수 있도록 `schema.json` 매핑이 필요합니다.
+- 대상 ComfyUI 서버에 필요한 커스텀 노드와 모델이 설치되어 있어야 합니다.
+
+`comfyui-skill workflow import`를 사용하면 CLI가 필요한 매핑을 생성하고 실행 전에 의존성을 확인할 수 있습니다.
+
+<a id="multi-server-management"></a>
+## 멀티 서버 관리
+
+이 프로젝트는 둘 이상의 ComfyUI 서버에서 작동하도록 설계되었습니다.
+
+여러 로컬 또는 원격 ComfyUI 인스턴스를 하나의 설정 아래에 두고 네임스페이스로 워크플로우를 라우팅할 수 있습니다. 경량 로컬 테스트, 대형 GPU 작업, 모델별 환경 등 다른 목적을 가진 머신에 유용합니다.
+
+예시:
+
+```bash
+comfyui-skill server add --id local --url http://127.0.0.1:8188
+comfyui-skill server add --id remote-a100 --url http://10.0.0.20:8188
+comfyui-skill server list
+```
+
+워크플로우는 다음 형식으로 주소 지정합니다:
+
+```text
+<server_id>/<workflow_id>
+```
+
+예시:
+
+```text
+local/txt2img
+remote-a100/sdxl-base
+```
+
+서버와 워크플로우 모두 활성화/비활성화 스위치를 지원하므로, 에이전트는 현재 사용 가능한 워크플로우만 볼 수 있습니다.
+
+다음 명령으로 머신 간 설정을 이동할 수도 있습니다:
+
+```bash
+comfyui-skill config export --output ./backup.json
+comfyui-skill config import ./backup.json --dry-run
+comfyui-skill config import ./backup.json
+```
+
+<a id="web-ui"></a>
+## Web UI
+
+시각적 설정 및 테스트를 위한 로컬 웹 인터페이스가 제공됩니다. 선택 사항이며, 설정, 검사, 검증을 더 쉽게 하기 위해 존재합니다. 스킬 자체는 에이전트가 CLI를 통해 사용하도록 설계되었습니다.
+
+### 실행
+
+```bash
+./ui/run_ui.sh                    # macOS/Linux
+# 또는: ui\run_ui.bat               # Windows
+```
+
+실행 스크립트는 필요 시 프로젝트 `.venv`를 생성하고 UI 의존성을 해당 가상 환경에 설치합니다. 글로벌 Web UI 의존성 설치는 필요 없습니다.
+
+`http://localhost:18189`를 방문하세요.
+
+### Web UI에서 할 수 있는 것
+
+- ComfyUI에서 내보낸 워크플로우 업로드
+- 시각적 편집기로 파라미터 매핑 설정
+- 여러 서버와 워크플로우를 한 곳에서 관리
+- 워크플로우 정의 검색, 정렬, 검사
+- 에이전트에 전달하기 전에 워크플로우 설정 테스트 및 검증
+- English, 简体中文, 繁體中文으로 인터페이스 언어 전환
+
+Web UI에서 설정하는 모든 것은 동일한 기반 CLI 워크플로우에 매핑됩니다. 별도의 실행 모델이 아닌 설정 및 테스트를 위한 시각적 동반자입니다.
+
+프론트엔드 소스는 [별도 리포지토리](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw-frontend)에 있습니다.
+
+## 자주 발생하는 문제
+
+### `/prompt`에서 HTTP 400
+
+워크플로우 페이로드 또는 주입된 파라미터 값 중 하나가 유효하지 않습니다.
+
+확인 사항:
+
+- 워크플로우가 API 형식으로 내보내졌는지
+- 스키마 매핑이 올바른 노드와 필드를 가리키는지
+- 제공된 인수 타입이 스키마와 일치하는지
+
+### 이미지가 반환되지 않음
+
+워크플로우에 `Save Image`와 같은 유효한 출력 노드가 없을 수 있습니다.
+
+### 연결 실패
+
+확인 사항:
+
+- ComfyUI 서버가 실행 중인지
+- `config.json`의 서버 URL이 올바른지
+- 선택한 서버가 활성화되어 있는지
+
+### 누락된 노드 또는 모델
+
+다음을 실행하세요:
+
+```bash
+comfyui-skill deps check <workflow_id>
+```
+
+그런 다음 필요한 의존성을 설치하세요.
+
+## 변경 이력
+
+최근 주요 변경사항:
+
+- **v0.4.0**: [CLI 우선 아키텍처](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI)로 마이그레이션 — 모든 워크플로우 작업(`run`, `submit`, `status`, `import`, `deps`)이 독립 CLI 도구를 통해 수행되며, 레거시 Python 스크립트는 제거되었습니다.
+- **v0.3.1**: Kling, Sora, Nano Banana 등 클라우드 API 노드를 위한 ComfyUI API Key 지원 추가.
+- **v0.3.0**: 의존성 확인 및 설치, 논블로킹 `submit`과 `status`, 이미지 업로드, 가져오기 미리보기, 실행 이력 추가.
+
+전체 릴리스 이력은 [CHANGELOG.md](./CHANGELOG.md)를 참조하세요.
+
+## 기여
+
+기여를 환영합니다! PR을 제출하기 전에 [CONTRIBUTING.md](./CONTRIBUTING.md)를 읽어주세요.
+
+## 관련 자료
+
+- [English README](./README.md)
+- [简体中文 README](./README.zh-CN.md)
+- [繁體中文 README](./README.zh-TW.md)
+- [日本語 README](./README.ja.md)
+- [한국어 README](./README.ko.md)
+- [Español README](./README.es.md)
+- [ComfyUI Skill CLI](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI)
+- [Frontend Repository](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw-frontend)

--- a/README.md
+++ b/README.md
@@ -22,15 +22,18 @@
     <a href="https://www.bilibili.com/video/BV1a6cUzVEE6/">🎬 Demo Video</a> ·
     <a href="https://huangyuchuh.github.io/ComfyUI_Skills_OpenClaw/">📘 Docs</a> ·
     <a href="#quick-start">🧭 Quick Start</a> ·
+    <a href="#cli">⌨️ CLI</a> ·
     <a href="#web-ui">🖥️ Web UI</a> ·
     <a href="#multi-server-management">🛰️ Multi-Server</a>
   </p>
 
   <p>
     <strong>English</strong> ·
-    <a href="./README.zh.md">简体中文</a> ·
+    <a href="./README.zh-CN.md">简体中文</a> ·
     <a href="./README.zh-TW.md">繁體中文</a> ·
-    <a href="./README.ja.md">日本語</a>
+    <a href="./README.ja.md">日本語</a> ·
+    <a href="./README.ko.md">한국어</a> ·
+    <a href="./README.es.md">Español</a>
   </p>
 </div>
 
@@ -254,6 +257,7 @@ data/local/my-workflow/
 
 </details>
 
+<a id="cli"></a>
 ## Common Commands
 
 Beyond the commands shown in [Quick Start](#quick-start), here are additional operations you may need:
@@ -409,8 +413,10 @@ Contributions are welcome! Please read [CONTRIBUTING.md](./CONTRIBUTING.md) befo
 ## Resources
 
 - [English README](./README.md)
-- [简体中文 README](./README.zh.md)
+- [简体中文 README](./README.zh-CN.md)
 - [繁體中文 README](./README.zh-TW.md)
 - [日本語 README](./README.ja.md)
+- [한국어 README](./README.ko.md)
+- [Español README](./README.es.md)
 - [ComfyUI Skill CLI](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI)
 - [Frontend Repository](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw-frontend)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,6 +22,7 @@
     <a href="https://www.bilibili.com/video/BV1a6cUzVEE6/">🎬 演示视频</a> ·
     <a href="https://huangyuchuh.github.io/ComfyUI_Skills_OpenClaw/">📘 文档站</a> ·
     <a href="#quick-start">🧭 快速开始</a> ·
+    <a href="#cli">⌨️ CLI</a> ·
     <a href="#web-ui">🖥️ Web UI</a> ·
     <a href="#multi-server-management">🛰️ 多服务器</a>
   </p>
@@ -30,7 +31,9 @@
     <a href="./README.md">English</a> ·
     <strong>简体中文</strong> ·
     <a href="./README.zh-TW.md">繁體中文</a> ·
-    <a href="./README.ja.md">日本語</a>
+    <a href="./README.ja.md">日本語</a> ·
+    <a href="./README.ko.md">한국어</a> ·
+    <a href="./README.es.md">Español</a>
   </p>
 </div>
 
@@ -303,6 +306,7 @@ ComfyUI workflow.json
 
 这种结构让 Agent 面对的是一个稳定的调用契约，而不是直接去理解原始的 ComfyUI graph 节点。
 
+<a id="cli"></a>
 ## 常用命令
 
 下面这些命令覆盖了最常见的使用场景。
@@ -481,8 +485,10 @@ comfyui-skill deps check <workflow_id>
 ## 相关资源
 
 - [English README](./README.md)
-- [简体中文 README](./README.zh.md)
+- [简体中文 README](./README.zh-CN.md)
 - [繁體中文 README](./README.zh-TW.md)
 - [日本語 README](./README.ja.md)
+- [한국어 README](./README.ko.md)
+- [Español README](./README.es.md)
 - [ComfyUI Skill CLI](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI)
 - [Frontend Repository](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw-frontend)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -22,15 +22,18 @@
     <a href="https://www.bilibili.com/video/BV1a6cUzVEE6/">🎬 示範影片</a> ·
     <a href="https://huangyuchuh.github.io/ComfyUI_Skills_OpenClaw/">📘 文件站</a> ·
     <a href="#quick-start">🧭 快速開始</a> ·
+    <a href="#cli">⌨️ CLI</a> ·
     <a href="#web-ui">🖥️ Web UI</a> ·
     <a href="#multi-server-management">🛰️ 多伺服器</a>
   </p>
 
   <p>
     <a href="./README.md">English</a> ·
-    <a href="./README.zh.md">简体中文</a> ·
+    <a href="./README.zh-CN.md">简体中文</a> ·
     <strong>繁體中文</strong> ·
-    <a href="./README.ja.md">日本語</a>
+    <a href="./README.ja.md">日本語</a> ·
+    <a href="./README.ko.md">한국어</a> ·
+    <a href="./README.es.md">Español</a>
   </p>
 </div>
 
@@ -303,6 +306,7 @@ ComfyUI workflow.json
 
 這種結構讓 Agent 面對的是一個穩定的呼叫契約，而不是直接去理解原始的 ComfyUI graph 節點。
 
+<a id="cli"></a>
 ## 常用命令
 
 下面這些命令覆蓋了最常見的使用場景。
@@ -481,8 +485,10 @@ comfyui-skill deps check <workflow_id>
 ## 相關資源
 
 - [English README](./README.md)
-- [简体中文 README](./README.zh.md)
+- [简体中文 README](./README.zh-CN.md)
 - [繁體中文 README](./README.zh-TW.md)
 - [日本語 README](./README.ja.md)
+- [한국어 README](./README.ko.md)
+- [Español README](./README.es.md)
 - [ComfyUI Skill CLI](https://github.com/HuangYuChuh/ComfyUI_Skill_CLI)
 - [Frontend Repository](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw-frontend)

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,5 +28,5 @@ comfyui-skill run local/txt2img --args '{"prompt": "a white cat"}'
 - [GitHub Repository](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw)
 - [CLI Tool (PyPI)](https://pypi.org/project/comfyui-skill-cli/)
 - [English README](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw/blob/main/README.md)
-- [Chinese README](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw/blob/main/README.zh.md)
+- [Chinese README](https://github.com/HuangYuChuh/ComfyUI_Skills_OpenClaw/blob/main/README.zh-CN.md)
 - [ComfyUI Native Routes Reference]({{ '/comfyui-native-routes/' | relative_url }})


### PR DESCRIPTION
## Summary
- Add `README.ko.md` (Korean) and `README.es.md` (Spanish) — P2 priority per SEO guideline, machine-translated with contribution notice
- Rename `README.zh.md` → `README.zh-CN.md` to follow BCP 47 naming convention (`zh-CN` instead of `zh`)
- Add ⌨️ CLI quick-nav link to the top banner of all 6 READMEs, pointing to internal Common Commands section (which links out to the CLI repo)
- Update all cross-references across 6 READMEs + `docs/index.md`

## Test plan
- [ ] Verify language switcher links work correctly on all 6 READMEs
- [ ] Verify `⌨️ CLI` nav link scrolls to the Common Commands section
- [ ] Verify `README.zh-CN.md` renders correctly (no broken links from rename)
- [ ] Verify Korean and Spanish READMEs render properly with machine translation notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)